### PR TITLE
Change build tool from conda-build to rattler-build and additional platforms

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,14 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+      linux_ppc64le_:
+        CONFIG: linux_ppc64le_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,6 +11,9 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,41 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+libarchive:
+- '3.8'
+ncurses:
+- '6'
+pcre2:
+- '10.45'
+readline:
+- '8'
+rust_compiler:
+- rust
+sqlite:
+- '3'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,41 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le:alma9
+libarchive:
+- '3.8'
+ncurses:
+- '6'
+pcre2:
+- '10.45'
+readline:
+- '8'
+rust_compiler:
+- rust
+sqlite:
+- '3'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,43 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+libarchive:
+- '3.8'
+macos_machine:
+- arm64-apple-darwin20.0.0
+ncurses:
+- '6'
+pcre2:
+- '10.45'
+readline:
+- '8'
+rust_compiler:
+- rust
+sqlite:
+- '3'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -48,6 +48,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -35,7 +35,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -49,7 +49,7 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
 fi
 
 
@@ -60,20 +60,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -89,6 +89,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+  pip rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"
@@ -70,33 +70,25 @@ source run_conda_forge_build_setup
 
 ( endgroup "Configuring conda" ) 2> /dev/null
 
-echo -e "\n\nMaking the build clobber file"
-make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build does not currently support debug mode"
 else
 
     if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
     fi
 
-    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
-        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+    rattler-build build --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="$flow_run_id" \
+        --extra-meta remote_url="$remote_url" \
+        --extra-meta sha="$sha"
 
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,31 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26055&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lnav-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26055&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lnav-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26055&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lnav-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26055&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/lnav-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About lnav-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/lnav-feedstock/blob/main/LICENSE.txt)
 
-Home: https://lnav.org
+Home: https://lnav.org/
 
 Package license: BSD-2-Clause
 
@@ -11,7 +11,7 @@ Summary: A log file viewer for the terminal
 
 Development: https://github.com/tstack/lnav
 
-Documentation: https://docs.lnav.org
+Documentation: https://docs.lnav.org/
 
 The Logfile Navigator is a log file viewer for the terminal. Given a set of files/directories, lnav will:
 
@@ -31,7 +31,6 @@ Then, in the lnav TUI, you can:
   - pretty-print structured text (press P);
   - view a histogram of messages over time (press i);
   - analyze messages using SQLite (press ;)
-
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,4 @@
+conda_build_tool: rattler-build
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,9 @@
-github:
-  branch_name: main
-  tooling_branch_name: main
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+build_platform:
+  osx_arm64: osx_64
+test: native_and_emulated

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-c_stdlib_version:          # [osx and x86_64]
-  - 10.15                  # [osx and x86_64]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,24 +1,27 @@
-{% set name = "lnav" %}
-{% set version = "0.12.4" %}
-
-package:
-  name: {{ name|lower }}
-  version: {{ version }}
-
-source:
-  url: https://github.com/tstack/{{ name|lower }}/releases/download/v{{ version }}/{{ name|lower }}-{{ version }}.tar.gz
+context:
+  name: lnav
+  version: "0.12.4"
   sha256: e1e70c9e5a2fce21da80eec9b9c3adb09fd05e03986285098a9f2567c1eb4792
 
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/tstack/${{ name }}/releases/download/v${{ version }}/${{ name }}-${{ version }}.tar.gz
+  sha256: ${{ sha256 }}
+
 build:
-  number: 1
-  skip: true  # [win]
+  number: 0
+  skip:
+    - win
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - {{ compiler('rust') }}
-    - {{ stdlib("c") }}
+    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
+    - ${{ compiler("rust") }}
+    - ${{ stdlib("c") }}
     - cargo-bundle-licenses
     - make
     - pkg-config
@@ -35,17 +38,16 @@ requirements:
     - sqlite
     - zlib
 
-test:
-  commands:
+tests:
+  - script:
     - lnav -V
     - printf 'lnav' | lnav -n -c ';from [{ col1=1 }] | take 1' | grep -q col1
 
 about:
-  home: https://lnav.org
-  dev_url: https://github.com/tstack/lnav
-  doc_url: https://docs.lnav.org
+  homepage: https://lnav.org
+  repository: https://github.com/tstack/lnav
+  documentation: https://docs.lnav.org
   license: BSD-2-Clause
-  license_family: BSD
   license_file:
     - LICENSE
     - THIRDPARTY.yml

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -1,0 +1,3 @@
+c_stdlib_version:
+  - if: osx and x86_64
+    then: 10.15


### PR DESCRIPTION
This pull request introduces support for additional platforms in the build pipeline and updates configuration files to accommodate these changes. The most important changes include adding configurations for `linux_aarch64`, `linux_ppc64le`, and `osx_arm64` platforms, modifying build scripts to handle cross-platform builds, and updating documentation to reflect the new platform support.

### Platform Support Enhancements:
* [`.azure-pipelines/azure-pipelines-linux.yml`](diffhunk://#diff-db71f153817776d1878eba60d2c71512969cca05e702cdc382ac178b6fb316dfR15-R22): Added configurations for `linux_aarch64` and `linux_ppc64le` platforms, including their respective Docker images.
* [`.azure-pipelines/azure-pipelines-osx.yml`](diffhunk://#diff-1784a4929597bf064ab5f096db3ef0b9ef7f2eac5092981fead7e8a35061bc3eR14-R16): Added configuration for the `osx_arm64` platform.
* [`.ci_support/linux_aarch64_.yaml`](diffhunk://#diff-408b74dae079881c0d15c7f4b73d08d9ed389c69397f5f86f0d94c2a4854d4a4R1-R41): Added detailed settings for `linux_aarch64`, including compiler versions, target platform, and dependencies.
* [`.ci_support/linux_ppc64le_.yaml`](diffhunk://#diff-3190fed5ebb234b0a002a306df50050c27966b8472a74cff06c84de06fd3b777R1-R41): Added detailed settings for `linux_ppc64le`, including compiler versions, target platform, and dependencies.
* [`.ci_support/osx_arm64_.yaml`](diffhunk://#diff-62483d82475da22a225a2d6e33c8a20200c57984daba86713e3d2581fbabf936R1-R43): Added detailed settings for `osx_arm64`, including macOS deployment target, SDK version, and dependencies.

### Build Script Modifications:
* [`.scripts/build_steps.sh`](diffhunk://#diff-22c5a202c93f351348030b671d6e0e1fdae11f4a23eeff71551c4ef90d88bddbR51-R53): Added logic to skip tests for cross-platform builds unless debugging is enabled.
* [`.scripts/run_osx_build.sh`](diffhunk://#diff-d10439659fe44156d9eac347f9e9eb6992e5b516d0f7e86df061c8273397fd7dR92-R95): Added logic to skip tests for cross-platform builds during macOS builds.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60-R87): Updated the build status table to include badges for `linux_aarch64`, `linux_ppc64le`, and `osx_arm64` platforms.

### Configuration Updates:
* [`conda-forge.yml`](diffhunk://#diff-478786365dd93f740eb520c2faa03d7a0623273663b75472272c8ef94297bbe2L1-R9): Updated platform providers and added cross-platform build settings for `osx_arm64`.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
